### PR TITLE
Restyle cookie consent banner

### DIFF
--- a/js/cok.js
+++ b/js/cok.js
@@ -21,60 +21,81 @@
         style.textContent = `
       #cookie-banner-wrapper {
         position: fixed;
-        z-index: 99999;
+        bottom: 0;
+        left: 0;
         width: 100%;
+        z-index: 99999;
         display: flex;
-        justify-content: flex-end;
+        justify-content: center;
         pointer-events: none;
+        padding: 16px;
+        box-sizing: border-box;
+        background: linear-gradient(to top, rgba(10, 10, 10, 0.85), rgba(10, 10, 10, 0));
       }
 
       #cookie-consent-banner {
-        background-color: #222;
-        color: #eee;
-        padding: 15px;
-        font-size: 14px;
-        font-family: Arial, sans-serif;
-        line-height: 1.4;
-        box-shadow: 0 0 10px rgba(0,0,0,0.7);
-        border-radius: 8px;
+        background-color: #1e1e1e;
+        color: #f5f5f5;
+        padding: 14px 20px;
+        font-size: 13px;
+        font-family: "Inter", "Segoe UI", Arial, sans-serif;
+        line-height: 1.5;
+        border-radius: 6px;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
         display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 10px;
-        opacity: 0;
-        transform: translateY(20px);
-        animation: cookieFadeIn 0.4s ease forwards;
+        align-items: center;
+        gap: 16px;
+        width: min(680px, calc(100% - 32px));
         pointer-events: auto;
-        box-sizing: border-box;
-        max-width: 320px;
-        margin: 20px;
+        opacity: 0;
+        transform: translateY(16px);
+        animation: cookieFadeIn 0.35s ease forwards;
       }
 
       #cookie-consent-banner.closing {
-        animation: cookieFadeOut 0.4s ease forwards;
+        animation: cookieFadeOut 0.35s ease forwards;
       }
 
-      #cookie-consent-banner span {
-        margin-right: 10px;
+      #cookie-consent-text {
+        flex: 1;
       }
 
       #cookie-consent-banner a {
-        color: #4CAF50;
+        color: #ff8c32;
+        text-decoration: none;
+        font-weight: 600;
+      }
+
+      #cookie-consent-banner a:hover,
+      #cookie-consent-banner a:focus {
         text-decoration: underline;
+      }
+
+      #cookie-btn-row {
+        display: flex;
+        gap: 10px;
+        flex-wrap: nowrap;
       }
 
       #cookie-consent-banner button {
         border: none;
-        padding: 8px 16px;
-        font-size: 14px;
+        padding: 10px 18px;
+        font-size: 13px;
+        font-weight: 600;
         cursor: pointer;
-        border-radius: 4px;
-        margin-right: 8px;
+        border-radius: 6px;
+        transition: transform 0.15s ease, opacity 0.15s ease;
       }
 
-      #cookie-accept { background-color: #4CAF50; color: white; }
-      #cookie-decline { background-color: #888; color: white; }
-      #cookie-btn-row { display: flex; flex-wrap: wrap; }
+      #cookie-consent-banner button:hover {
+        transform: translateY(-1px);
+      }
+
+      #cookie-accept { background-color: #ff6a00; color: #ffffff; }
+      #cookie-decline { background-color: #3c3f44; color: #f0f0f0; }
+
+      #cookie-decline:hover { opacity: 0.85; }
+      #cookie-accept:hover { opacity: 0.9; }
 
       #cookie-toast {
         position: fixed;
@@ -107,31 +128,20 @@
         }
       }
 
-      @media (max-width: 767px) {
-        #cookie-banner-wrapper {
-          bottom: 0;
-          justify-content: center;
-          padding: 0;
-        }
-
+      @media (max-width: 640px) {
         #cookie-consent-banner {
+          flex-direction: column;
+          align-items: stretch;
+          gap: 12px;
+        }
+
+        #cookie-btn-row {
           width: 100%;
-          max-width: 100%;
-          border-radius: 0;
-          margin: 0;
+          justify-content: flex-end;
         }
 
-        #cookie-toast {
-          right: 50%;
-          transform: translateX(50%);
-          bottom: 10px;
-        }
-      }
-
-      @media (min-width: 768px) {
-        #cookie-banner-wrapper {
-          bottom: 20px;
-          right: 20px;
+        #cookie-btn-row button {
+          flex: 1;
         }
       }
     `;
@@ -144,7 +154,8 @@
         banner.id = 'cookie-consent-banner';
 
         const text = document.createElement('span');
-        text.innerHTML = `This site uses cookies to improve your experience. By continuing, you accept our <a href="https://${window.location.hostname.split('.').slice(-2).join('.')}/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>.`;
+        text.id = 'cookie-consent-text';
+        text.innerHTML = `We use cookies to help personalize content and enhance your experience. <a href="https://${window.location.hostname.split('.').slice(-2).join('.')}/privacy" target="_blank" rel="noopener noreferrer">Learn more</a>.`;
 
         const btnAccept = document.createElement('button');
         btnAccept.id = 'cookie-accept';


### PR DESCRIPTION
## Summary
- refresh the cookie consent banner styling to match the new dark bar design with orange accept button
- adjust layout, typography, and link styling to mimic the provided reference
- keep responsive behaviour with updated mobile layout tweaks

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7b52ba52883278f845d1d2bc5761e